### PR TITLE
Split messages which exceed maximum size for keystone

### DIFF
--- a/exporter/keystoneexporter/exporter.go
+++ b/exporter/keystoneexporter/exporter.go
@@ -23,22 +23,10 @@ func (k keystoneExporter) Shutdown(ctx context.Context) error {
 }
 
 func (k keystoneExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
-	msg, err := k.getMessage(md)
-	if err != nil {
-		k.log.Error("failed to construct message", zap.Error(err))
-		return err
-	}
-
-	err = PublishMessage(msg)
-	if err != nil {
-		k.log.Error("failed to publish message", zap.Error(err))
-		return err
-	}
-
-	return nil
+	return k.publishMessages(md)
 }
 
-func (k keystoneExporter) getMessage(md pdata.Metrics) (*KsMessage, error) {
+func (k keystoneExporter) publishMessages(md pdata.Metrics) (error) {
 	events := make([]KsEvent, 0)
 
 	ocmds := internaldata.MetricsToOC(md)
@@ -64,7 +52,7 @@ func (k keystoneExporter) getMessage(md pdata.Metrics) (*KsMessage, error) {
 		}
 	}
 
-	return GetMessage(events)
+	return PublishMessages(events)
 }
 
 func isValidMetricType(metricType metricspb.MetricDescriptor_Type) bool {


### PR DESCRIPTION
Example of usual chunking behavior
```
"single message size: 8761334"}
"published keystone message with size: 450303"}
"single message size: 450303"}
"published keystone message with size: 8763503"}
"single message size: 8763503"}
"published keystone message with size: 8761357"}
"single message size: 8761357"}
"published keystone message with size: 450303"}
"single message size: 450303"}
```

Example of splitting output
```
"splitting message of size: 17941313"}
"splitting message of size: 8970628"}
"single message size: 4521414"}
"single message size: 4449348"}
"splitting message of size: 8970819"}
"single message size: 4521527"}
"single message size: 4449426"}
"published keystone message with size: 4521414"}
"published keystone message with size: 4449348"}
"published keystone message with size: 4521527"}
"published keystone message with size: 4449426"}
```