### PR TITLE
Source netflix_environment.sh for systemd service

### DIFF
--- a/internal/buildscripts/packaging/fpm/otel-contrib-collector.service
+++ b/internal/buildscripts/packaging/fpm/otel-contrib-collector.service
@@ -3,6 +3,7 @@ Description=OpenTelemety Contrib Collector
 After=network.target
 
 [Service]
+EnvironmentFile=/etc/profile.d/netflix_environment.sh
 ExecStart=/usr/bin/otelcontribcol --config /etc/otel-contrib-collector/config.yaml
 KillMode=mixed
 Restart=on-failure


### PR DESCRIPTION
The debian version will not start because NETFLIX_STACK is not defined (as required by keystoneexporter), because netflix_environment.sh is not sourced.
I'm not sure how to test that this works, if someone wants to walk me through how packaging works I can try it out.