### PR TITLE
Discover network namespaces the VK way

### DIFF
--- a/exporter/tituskubeletspectatordexporter/exporter.go
+++ b/exporter/tituskubeletspectatordexporter/exporter.go
@@ -83,7 +83,7 @@ func (e *spectatorExporter) getPodName(descriptor *metricspb.MetricDescriptor, s
 	labelKeys := descriptor.GetLabelKeys()
 	labelValues := series.GetLabelValues()
 	for i, key := range labelKeys {
-		if key.GetKey() == "pod" && labelValues[i].HasValue {
+		if key.GetKey() == "taskId" && labelValues[i].HasValue {
 			return labelValues[i].GetValue(), nil
 		}
 	}

--- a/exporter/tituskubeletspectatordexporter/network.go
+++ b/exporter/tituskubeletspectatordexporter/network.go
@@ -1,19 +1,13 @@
 package tituskubeletspectatordexporter
 
 import (
-	"io/ioutil"
 	"path"
 )
 
-// e.g. /var/lib/titus-environments/fe9298a0-1a0b-4cae-b292-5e5982e251db/netns
-const titusEnvironmentsPath = "/var/lib/titus-environments"
-const networkNamespaceFileName = "netns"
+// e.g. /var/lib/titus-inits/6ea18999-e06b-44ce-b9a5-f4ff55883680/ns/net
+const titusEnvironmentsPath = "/var/lib/titus-inits"
+const networkNamespaceFileName = "ns/net"
 
 func GetNetworkNamespacePath(podName string) (string, error) {
-	netNsPath := path.Join(titusEnvironmentsPath, podName, networkNamespaceFileName)
-	if content, err := ioutil.ReadFile(netNsPath); err != nil {
-		return "", err
-	} else {
-		return string(content), nil
-	}
+	return path.Join(titusEnvironmentsPath, podName, networkNamespaceFileName), nil
 }

--- a/go.sum
+++ b/go.sum
@@ -193,7 +193,6 @@ github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.35.5/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
-github.com/aws/aws-sdk-go v1.36.2/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.36.9 h1:TS667yc08a/EHGBqFrfOItpnzSrBFwIf2gQGlDhhQsg=
 github.com/aws/aws-sdk-go v1.36.9/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=


### PR DESCRIPTION
This updates the per-container spectatord exporter to discover network namespaces according to the conventions of the virtual-kubelet